### PR TITLE
🔧 Add babel-preset-es2015 for the NODE_ENV=test

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -19,7 +19,13 @@
       ]
     },
 
-    <% } %>"production": {
+    <% } %>
+    <% if (jest) { %>"test": {
+      "presets": ["es2015"]           
+    },
+    <% } %>
+
+    "production": {
       "plugins": [
         "lodash"<% if (react) { %>,
         "transform-react-remove-prop-types"<% } %>


### PR DESCRIPTION
> Without this Jest will not be able to use import and other features that currently need to be transpiled with babel.

### Screenshot failing:
![image](https://cloud.githubusercontent.com/assets/6213695/21850864/ed54bf2c-d80c-11e6-8a02-d805205a0002.png)

### Screenshot with changes in this PR applied:
![image](https://cloud.githubusercontent.com/assets/6213695/21850902/1f7bf6d2-d80d-11e6-82ff-bfbf8be0cade.png)

Would have seemed logical that setting the global preset es2015 would also take care of Jest, but my guess is since that Jest exports a new env or runs under NODE_ENV=test that this doesn't work.